### PR TITLE
[NME-487] H2 dependency replaced by testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,8 @@
         <guava.version>30.0-jre</guava.version>
         <antlr4-runtime.version>4.7.2</antlr4-runtime.version>
 
-        <h2.version>1.4.200</h2.version>
-
         <spring-javaformat.version>0.0.25</spring-javaformat.version>
+        <testcontainers.mysql.version>1.16.0</testcontainers.mysql.version>
     </properties>
 
     <dependencies>
@@ -57,9 +56,14 @@
 
         <!-- TEST DEPENDENCIES -->
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.mysql.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/br/com/monkey/ecx/SpecificationBuilderTest.java
+++ b/src/test/java/br/com/monkey/ecx/SpecificationBuilderTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
@@ -18,11 +19,17 @@ import java.time.Instant;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { SpringSpecificationSearchApplication.class })
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureTestDatabase(replace = NONE)
+@TestPropertySource(properties = { "spring.jpa.hibernate.ddl-auto=create-drop", "spring.flyway.enabled=false",
+		"monkey.flyway.enabled=false", "internationalization.country=BR", "internationalization.language=pt-BR",
+		"internationalization.timezone=GMT-3",
+		"spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+		"spring.datasource.url=jdbc:tc:mysql:5.7.22:///monkey_test" })
 class SpecificationBuilderTest {
 
 	@Autowired

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,0 @@
-spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa


### PR DESCRIPTION
## Tipo da Alteração

- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement
- [ ] Refactoring

## Descrição
Exclusão da lib H2 do projeto e os testes foram alterados para rodar com testcontainers(mysql). 

## Motivação
Deixar os testes integrados muito mais próximo do ambiente real de execução.

## Como Você Testou a Alteração
**- Build:**
![build](https://user-images.githubusercontent.com/4533316/148567560-f0dc6081-3b71-48e1-8609-de1194594b77.png)

## Checklist
- [x] Código revisado antes de abrir o PR?
- [ ] Testes foram criados e eles estão dentro do coverage esperado?
- [ ] Foi criada alguma feature toggle, se sim ela foi adicionada ao board?
- [ ] Foi alterada alguma config?
- [ ] Foi criado scripts de flyway?
- [ ] Foi alterado algum teste de contrato?

## Próximos passos
N/A.
