### PR TITLE
[NME-487] H2 dependency replaced by testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <antlr4-runtime.version>4.7.2</antlr4-runtime.version>
 
         <spring-javaformat.version>0.0.25</spring-javaformat.version>
-        <testcontainers.mysql.version>1.16.0</testcontainers.mysql.version>
+        <testcontainers.mysql.version>1.16.3</testcontainers.mysql.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/br/com/monkey/ecx/SpecificationBuilderTest.java
+++ b/src/test/java/br/com/monkey/ecx/SpecificationBuilderTest.java
@@ -27,7 +27,8 @@ import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTest
 @AutoConfigureTestDatabase(replace = NONE)
 @TestPropertySource(properties = { "spring.jpa.hibernate.ddl-auto=create-drop", "spring.flyway.enabled=false",
 		"monkey.flyway.enabled=false", "internationalization.country=BR", "internationalization.language=pt-BR",
-		"internationalization.timezone=GMT-3",
+		"internationalization.timezone=GMT-3", "spring.datasource.hikari.minimum-idle=1",
+		"spring.datasource.hikari.initialization-fail-timeout=0", "spring.datasource.hikari.maximum-pool-size=1",
 		"spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
 		"spring.datasource.url=jdbc:tc:mysql:5.7.22:///monkey_test" })
 class SpecificationBuilderTest {


### PR DESCRIPTION
## Tipo da Alteração

- [ ] Bugfix
- [ ] New Feature
- [x] Enhancement
- [ ] Refactoring

## Descrição
Exclusão da lib H2 do projeto e os testes foram alterados para rodar com testcontainers(mysql). 

## Motivação
Deixar os testes integrados muito mais próximo do ambiente real de execução.

## Como Você Testou a Alteração
**- Build:**
![image](https://user-images.githubusercontent.com/4533316/153190391-ae6750c3-b63d-42ad-90be-13041cd332ff.png)

## Checklist
- [x] Código revisado antes de abrir o PR?
- [ ] Testes foram criados e eles estão dentro do coverage esperado?
- [ ] Foi criada alguma feature toggle, se sim ela foi adicionada ao board?
- [ ] Foi alterada alguma config?
- [ ] Foi criado scripts de flyway?
- [ ] Foi alterado algum teste de contrato?

## Próximos passos
N/A.
